### PR TITLE
Unify agent entry point with natural language routing

### DIFF
--- a/lib/ragnar/agent.rb
+++ b/lib/ragnar/agent.rb
@@ -37,6 +37,7 @@ module Ragnar
       - When finished, ALWAYS call task_complete with a summary
       - If you need clarification, call ask_user
       - Be concise and direct
+      /no_think
     PROMPT
 
     def initialize(profile: nil)
@@ -107,8 +108,21 @@ module Ragnar
     private
 
     def register_tools
-      Ragnar::Tools::ALL.each do |tool_class|
+      tools = select_tool_set
+      tools.each do |tool_class|
         @chat.with_tool(tool_class.new)
+      end
+    end
+
+    # Local models (red_candle) get overwhelmed by many tools with long
+    # descriptions — Qwen3-8B outputs only <think> blocks with 9 tools.
+    # Cloud models (Anthropic, OpenAI) handle the full set fine.
+    def select_tool_set
+      provider = Config.instance.llm_provider
+      if provider == 'red_candle'
+        Ragnar::Tools::LITE
+      else
+        Ragnar::Tools::ALL
       end
     end
 

--- a/lib/ragnar/agent.rb
+++ b/lib/ragnar/agent.rb
@@ -17,21 +17,26 @@ module Ragnar
     attr_reader :chat, :files_modified, :tool_calls_log
 
     SYSTEM_PROMPT = <<~PROMPT
-      You are a helpful coding assistant. You have access to tools for reading files,
-      writing files, editing files, executing bash commands, listing files, and searching
-      file contents.
+      You are a helpful assistant with two types of capabilities:
 
-      When working on a task:
-      1. Start by understanding the codebase — read relevant files, list directories
-      2. Make changes incrementally — edit or write files as needed
-      3. Verify your changes — run tests or check the output
-      4. When finished, call the task_complete tool with a summary
+      KNOWLEDGE BASE (search_docs tool):
+        Search indexed documents, policies, and documentation. Use this when the user
+        asks questions about information that would be in documents — "what is our
+        password policy?", "how does authentication work?", etc.
 
-      IMPORTANT:
-      - When you have completed the task, you MUST call the task_complete tool. Do not
-        just say you're done in text — use the tool.
-      - If you need clarification from the user, call the ask_user tool.
-      - Be concise and direct. Prefer editing existing files over creating new ones.
+      CODING TOOLS (read_file, write_file, edit_file, bash_exec, list_files, grep):
+        Read and modify source code files, and run commands. Use these when the user
+        asks you to examine, create, or modify code — "fix the bug in parser.rb",
+        "create a fizzbuzz script", etc.
+
+      Guidelines:
+      - Questions about information/knowledge → use search_docs first
+      - Tasks involving file changes → use coding tools
+      - Hybrid tasks ("summarize our security docs into a file") → search_docs to
+        gather information, then coding tools to create the output
+      - When finished, ALWAYS call task_complete with a summary
+      - If you need clarification, call ask_user
+      - Be concise and direct
     PROMPT
 
     def initialize(profile: nil)

--- a/lib/ragnar/cli.rb
+++ b/lib/ragnar/cli.rb
@@ -25,19 +25,14 @@ module Ragnar
       allow_nested: false,
       history_file: Config.instance.history_file,
       ui_mode: :tui,
+      # Route all natural language input through the unified Agent.
+      # The Agent decides whether to use SearchDocs (RAG), coding tools, or both.
       default_handler: proc do |input, thor_instance|
-        puts "[DEBUG] Default handler called: #{input}" if ENV["DEBUG"]
-
         begin
-          # IMPORTANT: Use direct method call, NOT invoke(), to avoid Thor's
-          # silent deduplication that prevents repeated calls to the same method
-          result = thor_instance.query(input.strip)
-          puts "[DEBUG] Default handler completed" if ENV["DEBUG"]
-          result
+          thor_instance.send(:unified_ask, input.strip)
         rescue => e
-          puts "[DEBUG] Default handler error: #{e.message}" if ENV["DEBUG"]
-          puts "[DEBUG] Backtrace: #{e.backtrace.first(3)}" if ENV["DEBUG"]
-          raise e
+          thor_instance.say "Error: #{e.message}", :red
+          thor_instance.say e.backtrace.first(3).join("\n") if ENV["DEBUG"]
         end
       end
     )
@@ -49,6 +44,8 @@ module Ragnar
     class_variable_set(:@@cached_query_processor, nil)
     class_variable_set(:@@cached_db_path, nil)
     class_variable_set(:@@verbose_mode, false)
+    class_variable_set(:@@cached_agent, nil)
+    class_variable_set(:@@cached_orchestrator, nil)
 
     desc "index PATH", "Index text files from PATH (file or directory)"
     option :db_path, type: :string, desc: "Path to Lance database (default from config)"
@@ -442,6 +439,8 @@ module Ragnar
         begin
           config.set_active_profile(name)
           LLMManager.instance.clear_cache
+          @@cached_agent = nil
+          @@cached_orchestrator = nil
           say "Switched to profile: #{name}", :green
           say "  Provider: #{config.llm_provider}"
           say "  Model: #{config.llm_model}"
@@ -688,6 +687,36 @@ module Ragnar
     end
 
     private
+
+    def unified_ask(input)
+      @@cached_agent ||= begin
+        a = Agent.new(profile: options[:profile])
+        a.on_tool_call do |tool_call|
+          say "  -> #{tool_call.name}(#{format_tool_args(tool_call.arguments)})", :cyan
+        end
+        a
+      end
+
+      @@cached_orchestrator ||= Orchestrator.new(
+        agent: @@cached_agent,
+        working_dir: Dir.pwd,
+        max_iterations: 20
+      )
+
+      @@cached_orchestrator.run(input) do |event|
+        case event[:type]
+        when :response
+          say "\n#{event[:content]}\n" if event[:content] && !event[:content].empty?
+        when :status
+          say event[:message], :yellow
+        when :validation
+          say "Running: #{event[:command]}", :yellow
+        when :ask_user
+          say event[:message], :yellow
+          ask("  > ")
+        end
+      end
+    end
 
     def apply_profile!
       return unless options[:profile]

--- a/lib/ragnar/query_processor.rb
+++ b/lib/ragnar/query_processor.rb
@@ -16,6 +16,39 @@ module Ragnar
       @reranker = nil # Will initialize when needed
     end
     
+    # Retrieve context without generating a response. Runs steps 1-5 of the
+    # RAG pipeline (rewrite, retrieve, rerank, prepare, repack) and returns
+    # the repacked context, sources, and confidence. Used by SearchDocs tool
+    # so the Agent LLM can synthesize its own answer.
+    def retrieve_context(user_query, top_k: 3, enable_rewriting: true, enable_reranking: false)
+      rewritten = build_rewritten_query(user_query, enable_rewriting: enable_rewriting)
+      candidates = retrieve_with_rrf(rewritten['sub_queries'], k: 20, verbose: false)
+
+      return { context: "", sources: [], confidence: 0.0, clarified: user_query } if candidates.empty?
+
+      if enable_reranking
+        reranked = rerank_documents(query: user_query, documents: candidates, top_k: top_k * 2)
+      else
+        reranked = candidates
+      end
+
+      context_docs = prepare_context(reranked[0...top_k], rewritten['context_needed'])
+      repacked = ContextRepacker.repack(context_docs, rewritten['clarified_intent'])
+      confidence = calculate_confidence(context_docs)
+
+      {
+        context: repacked,
+        sources: context_docs.map { |d|
+          {
+            source_file: d[:file_path] || d[:source_file] || d["file_path"],
+            chunk_index: d[:chunk_index] || d["chunk_index"]
+          }
+        }.reject { |s| s[:source_file].nil? },
+        confidence: confidence,
+        clarified: rewritten['clarified_intent']
+      }
+    end
+
     def query(user_query, top_k: 3, verbose: false, enable_rewriting: true, enable_reranking: false)
       puts "Processing query: #{user_query}" if verbose
       
@@ -434,6 +467,26 @@ module Ragnar
     def strip_think_tags(text)
       return text unless text
       text.gsub(/<think>.*?<\/think>/m, '').strip
+    end
+
+    def build_rewritten_query(user_query, enable_rewriting: true)
+      if enable_rewriting
+        rewritten = @rewriter.rewrite(user_query)
+        sub_queries = rewritten['sub_queries'] || []
+        unless sub_queries.include?(user_query)
+          sub_queries.unshift(user_query)
+        end
+        rewritten['sub_queries'] = sub_queries
+        rewritten
+      else
+        {
+          'clarified_intent' => user_query,
+          'query_type' => 'direct',
+          'context_needed' => 'general',
+          'sub_queries' => [user_query],
+          'key_terms' => []
+        }
+      end
     end
 
     def calculate_confidence(documents)

--- a/lib/ragnar/tools.rb
+++ b/lib/ragnar/tools.rb
@@ -9,6 +9,7 @@ require_relative "tools/grep"
 require_relative "tools/search_docs"
 require_relative "tools/task_complete"
 require_relative "tools/ask_user"
+require_relative "tools/lite"
 
 module Ragnar
   module Tools

--- a/lib/ragnar/tools.rb
+++ b/lib/ragnar/tools.rb
@@ -6,6 +6,7 @@ require_relative "tools/edit_file"
 require_relative "tools/bash_exec"
 require_relative "tools/list_files"
 require_relative "tools/grep"
+require_relative "tools/search_docs"
 require_relative "tools/task_complete"
 require_relative "tools/ask_user"
 
@@ -24,6 +25,7 @@ module Ragnar
       Tools::BashExec,
       Tools::ListFiles,
       Tools::Grep,
+      Tools::SearchDocs,
       Tools::TaskComplete,
       Tools::AskUser
     ].freeze

--- a/lib/ragnar/tools/lite.rb
+++ b/lib/ragnar/tools/lite.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Ragnar
+  module Tools
+    # Lite tool set for local models (Qwen3-8B, etc.)
+    #
+    # Small local models get overwhelmed when too many tools with long
+    # descriptions are registered. The full tool set (9 tools) causes
+    # Qwen3-8B to output only <think> blocks without making any tool calls.
+    # With 4 tools and short descriptions, it works reliably.
+    #
+    # Cloud models (Claude, GPT-4) handle the full tool set fine.
+
+    class LiteWriteFile < RubyLLM::Tool
+      description "Write a file"
+      param :path, desc: "File path"
+      param :content, desc: "File content"
+
+      def execute(path:, content:)
+        expanded = File.expand_path(path)
+        FileUtils.mkdir_p(File.dirname(expanded))
+        File.write(expanded, content)
+        "Wrote #{content.length} bytes to #{path}"
+      rescue => e
+        "Error: #{e.message}"
+      end
+    end
+
+    class LiteReadFile < RubyLLM::Tool
+      description "Read a file"
+      param :path, desc: "File path"
+
+      def execute(path:)
+        expanded = File.expand_path(path)
+        return "Error: not found: #{path}" unless File.exist?(expanded)
+        File.read(expanded)
+      rescue => e
+        "Error: #{e.message}"
+      end
+    end
+
+    class LiteBashExec < RubyLLM::Tool
+      description "Run a bash command"
+      param :command, desc: "The command to run"
+
+      def execute(command:)
+        stdout, stderr, status = Open3.capture3("bash", "-c", command, stdin_data: "")
+        parts = ["Exit: #{status.exitstatus}"]
+        parts << stdout unless stdout.empty?
+        parts << "stderr: #{stderr}" unless stderr.empty?
+        parts.join("\n")
+      rescue => e
+        "Error: #{e.message}"
+      end
+    end
+
+    class LiteTaskComplete < RubyLLM::Tool
+      description "Signal that the task is done"
+      param :summary, desc: "What was done"
+
+      def execute(summary:)
+        halt(summary)
+      end
+    end
+
+    LITE = [
+      LiteReadFile,
+      LiteWriteFile,
+      LiteBashExec,
+      LiteTaskComplete
+    ].freeze
+  end
+end

--- a/lib/ragnar/tools/search_docs.rb
+++ b/lib/ragnar/tools/search_docs.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Ragnar
+  module Tools
+    # SearchDocs bridges the RAG pipeline into the Agent's tool set.
+    #
+    # This is how the Agent accesses indexed knowledge — company documents,
+    # policies, technical docs, anything that's been indexed with `ragnar index`.
+    #
+    # Key design decision: this tool returns the RETRIEVED CONTEXT (document
+    # chunks + sources), not an LLM-generated answer. The Agent synthesizes
+    # the answer itself using the context plus its full conversation history.
+    # This avoids a double-LLM problem where the RAG pipeline generates an
+    # answer and the Agent then paraphrases it.
+    class SearchDocs < RubyLLM::Tool
+      description "Search the indexed knowledge base for information. Use this when the user " \
+                  "asks questions about documents, policies, procedures, or any previously " \
+                  "indexed content. Returns relevant document excerpts with source citations."
+
+      param :query, desc: "The search query — what information to find"
+      param :top_k, desc: "Number of results to return (default: 5)", type: :integer, required: false
+
+      def execute(query:, top_k: 5)
+        config = Config.instance
+        processor = QueryProcessor.new(db_path: config.database_path)
+        result = processor.retrieve_context(
+          query,
+          top_k: top_k || 5,
+          enable_rewriting: config.enable_query_rewriting?,
+          enable_reranking: config.enable_reranking?
+        )
+
+        if result[:context].empty?
+          return "No relevant documents found for: #{query}"
+        end
+
+        output = "## Retrieved Context\n\n"
+        output += result[:context]
+        output += "\n\n## Sources\n"
+        result[:sources].each_with_index do |s, i|
+          output += "#{i + 1}. #{s[:source_file]}"
+          output += " (chunk #{s[:chunk_index]})" if s[:chunk_index]
+          output += "\n"
+        end
+        output += "\nConfidence: #{result[:confidence]}%"
+        output
+      rescue => e
+        "Error searching documents: #{e.message}"
+      end
+    end
+  end
+end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Ragnar::Agent do
     it "creates a chat with tools registered" do
       agent = described_class.new
       expect(mock_chat).to have_received(:with_instructions)
-      expect(mock_chat).to have_received(:with_tool).at_least(9).times
+      # Tool count depends on provider — LITE (4) for red_candle, ALL (9) for cloud
+      expect(mock_chat).to have_received(:with_tool).at_least(4).times
     end
 
     it "accepts a profile option" do

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Ragnar::Agent do
     it "creates a chat with tools registered" do
       agent = described_class.new
       expect(mock_chat).to have_received(:with_instructions)
-      expect(mock_chat).to have_received(:with_tool).at_least(6).times
+      expect(mock_chat).to have_received(:with_tool).at_least(9).times
     end
 
     it "accepts a profile option" do

--- a/spec/unit/tools/search_docs_spec.rb
+++ b/spec/unit/tools/search_docs_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Ragnar::Tools::SearchDocs do
+  let(:tool) { described_class.new }
+  let(:mock_processor) { instance_double(Ragnar::QueryProcessor) }
+
+  before do
+    allow(Ragnar::QueryProcessor).to receive(:new).and_return(mock_processor)
+  end
+
+  describe "#execute" do
+    it "returns formatted search results" do
+      allow(mock_processor).to receive(:retrieve_context).and_return({
+        context: "Passwords must be at least 12 characters.",
+        sources: [
+          { source_file: "/docs/Password Policy.docx", chunk_index: 0 }
+        ],
+        confidence: 85.5,
+        clarified: "password policy"
+      })
+
+      result = tool.execute(query: "What is our password policy?")
+      expect(result).to include("Retrieved Context")
+      expect(result).to include("Passwords must be at least 12 characters")
+      expect(result).to include("Password Policy.docx")
+      expect(result).to include("85.5%")
+    end
+
+    it "handles empty results" do
+      allow(mock_processor).to receive(:retrieve_context).and_return({
+        context: "",
+        sources: [],
+        confidence: 0.0,
+        clarified: "query"
+      })
+
+      result = tool.execute(query: "something not indexed")
+      expect(result).to include("No relevant documents found")
+    end
+
+    it "handles errors gracefully" do
+      allow(mock_processor).to receive(:retrieve_context)
+        .and_raise("Database connection failed")
+
+      result = tool.execute(query: "test")
+      expect(result).to include("Error searching documents")
+    end
+  end
+
+  describe "tool metadata" do
+    it "has a description mentioning knowledge base" do
+      expect(tool.description).to include("knowledge base")
+    end
+
+    it "has a name" do
+      expect(tool.name).to include("search_docs")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Eliminates the split between `/query` (RAG) and `/code` (agent) — all input now goes through a single Agent that decides whether to search documents or write code based on natural language.

### SearchDocs Tool
- Wraps the RAG retrieval pipeline as a `RubyLLM::Tool`
- Returns retrieved context + sources (not LLM-generated answer) so the Agent synthesizes its own response — avoids double-LLM problem
- New `retrieve_context` public method on QueryProcessor (DRY extraction of steps 1-5)

### Unified Default Handler
- TUI routes all natural language input through a cached Agent + Orchestrator
- "What is our password policy?" → Agent calls `search_docs`
- "Create fizzbuzz.rb and run it" → Agent uses `write_file` + `bash_exec`
- `/query` and `/code` still work as explicit alternatives

### Lite Tool Set for Local Models
- Small local models (Qwen3-8B) get overwhelmed with 9 tools + long descriptions — they output only `<think>` blocks
- Lite set: 4 tools with minimal descriptions (`LiteReadFile`, `LiteWriteFile`, `LiteBashExec`, `LiteTaskComplete`)
- Agent auto-selects: `red_candle` → LITE (4 tools), cloud providers → ALL (9 tools)
- Tested: Qwen3-8B successfully writes files, runs bash, and calls task_complete through the full loop

### Other
- Profile switching clears cached agent/orchestrator
- `/no_think` added to Agent system prompt
- System prompt guides LLM on when to use knowledge base vs coding tools

## Test plan

- [x] 392 specs, 0 failures
- [x] Qwen3-8B with lite tools: writes files, runs commands, calls task_complete
- [x] Opus with full tools: all 9 tools work
- [x] `/query` and `/code` still work as explicit commands
- [x] Profile switching clears and rebuilds agent


🤖 Generated with [Claude Code](https://claude.com/claude-code)