### PR TITLE
Release 0.1.0.pre.5

### DIFF
--- a/lib/ragnar/version.rb
+++ b/lib/ragnar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ragnar
-  VERSION = "0.1.0.pre.4"
+  VERSION = "0.1.0.pre.5"
 end


### PR DESCRIPTION
Version bump to 0.1.0.pre.5. Protected main requires a PR; the release is then cut via the version-box workflow_dispatch (which no-ops the branch push and pushes only the tag).